### PR TITLE
Fix logic error in plugin loader

### DIFF
--- a/webware/PlugInLoader.py
+++ b/webware/PlugInLoader.py
@@ -53,12 +53,12 @@ class PlugInLoader:
             if name in plugIns:
                 if verbose:
                     print(f'Plug-in {name} has already been loaded.')
-                    continue
+                continue
             entry_point = entryPoints.get(name)
             if not entry_point:
                 if verbose:
                     print(f'Plug-in {name} has not entry point.')
-                    continue
+                continue
             module = entry_point.load()
             plugIn = self.loadPlugIn(name, module, verbose=verbose)
             if plugIn:


### PR DESCRIPTION
The logic should be same with or without verbose mode.

In my situation I was trying to load a plugin that doesn't have an entry point.  It worked when verbose was True, but failed with a traceback when verbose was False.
